### PR TITLE
Prevent user authentication with empty password

### DIFF
--- a/providers/LHLDAPApi.php
+++ b/providers/LHLDAPApi.php
@@ -50,7 +50,7 @@ class LHLDAPApi {
             return throw new \Exception(\erTranslationClassLhTranslation::getInstance()->getTranslation('lhldap/module', 'To mane record found with username. One record is expected.'));
         } else if ( is_array( $userinfo[0] ) ) {
             if ( !$password ) {
-                return $userinfo[0] ;
+                throw new \Exception(\erTranslationClassLhTranslation::getInstance()->getTranslation('lhldap/module', 'Password is required for authentication.'));
             } else if ( isset( $userinfo[0]['dn'] ) ) {
                 $userdn = $userinfo[0]['dn'] ;
                 $result = @ldap_bind( self::getConnection(), $userdn, $password );


### PR DESCRIPTION
**Issue**
This line allows users to authenticate with an empty password :)

This is probably for the Test LDAP function to work in the UI module settings. This approach isn't ideal, as it breaks the 'Test LDAP' function in the UI. It's rather to bring awareness.

I'd guess this was originally implemented to support the “Test LDAP” functionality in the UI module settings. However, this approach introduces a critical bypass: if no password is provided, authentication is still considered successful.

The proposed fix is not ideal as it breaks this "Test LDAP" function.